### PR TITLE
update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/mssql-server-linux
+FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
 LABEL AUTHOR="Luiz Carlos Faria <luizcarlosfaria@gmail.com>"
 
 VOLUME /docker-entrypoint-initdb.d

--- a/docker-entrypoint-initdb.sh
+++ b/docker-entrypoint-initdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f /init.lock ]; then
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "$0: Starting SQL Server"
 docker-entrypoint-initdb.sh & /opt/mssql/bin/sqlservr


### PR DESCRIPTION
 - Using the latest update fo sql server on linux as base image.
- According with the instructions in [Sql Server repository](https://hub.docker.com/_/microsoft-mssql-server)  the tag `2017-latest-ubuntu` is the up to date version in the Microsoft container register `mcr.microsoft.com/mssql/server`.  