### PR TITLE
atualização para imagem do sql 2019 no ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY ./docker-entrypoint.sh             /usr/local/bin/
 
 COPY ./docker-entrypoint-initdb.sh      /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh 
-RUN chmod +x /usr/local/bin/docker-entrypoint-initdb.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+   && chmod +x /usr/local/bin/docker-entrypoint-initdb.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+FROM mcr.microsoft.com/mssql/server:2019-latest
 LABEL AUTHOR="Luiz Carlos Faria <luizcarlosfaria@gmail.com>"
+# RUN cat /etc/*release
+# RUN cat /etc/passwd
 
 VOLUME /docker-entrypoint-initdb.d
 
 ENV MSSQL_DATABASE_COLLATE=SQL_Latin1_General_CP1_CI_AI
 
 EXPOSE 1433
+# Necessário trocar o usuário para o root devido ao permissão na pasta /opt/mssql-tools/bin
+USER root
 
 RUN ln -s /opt/mssql-tools/bin/sqlcmd   /usr/local/bin/sqlcmd \
     && ln -s /opt/mssql-tools/bin/bcp   /usr/local/bin/bcp


### PR DESCRIPTION
Atualizado para Imagem mcr.microsoft.com/mssql/server:2019-latest 
Execução do build-and-test.sh com sucesso foi criado a base e o usuário
Tentei voltar a imagem para o usuário defaul "mssql" mas da erro de permissão quando executa os comando para criação da base e dos usuários